### PR TITLE
Fix Breakpoint Styler For Methods in Parenthesis

### DIFF
--- a/src/GToolkit-Debugger/GtDebuggerCoderBreakpointStyler.class.st
+++ b/src/GToolkit-Debugger/GtDebuggerCoderBreakpointStyler.class.st
@@ -41,7 +41,7 @@ GtDebuggerCoderBreakpointStyler >> visitMessage: aMessage [
 			[:each |
 			each hasBreakpoint and: 
 					[each selectorNode start = aMessage startPosition
-						and: [each stop = aMessage stopPosition]]]
+						and: [each stopWithoutParentheses = aMessage stopPosition]]]
 		ifFound: [:node | self showBreakpointFor: node at: aMessage startPosition - 1]
 ]
 


### PR DESCRIPTION
The parenthesis should not be included for the matching. Code to reproduce the issue with trying to put a breakpoint on #bubu:
```
toto
	(self bubu: true) asPdf
```